### PR TITLE
63 - Launch HC Independently

### DIFF
--- a/FAST2/MainWindow.xaml
+++ b/FAST2/MainWindow.xaml
@@ -20,10 +20,10 @@
     Title="FAST"
     Icon="FAST-main-icon.ico"
 
-    Height="600"
+    Height="650"
     Width="1000"
     MinWidth="1000"
-    MinHeight="600"
+    MinHeight="650"
 
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"

--- a/FAST2/ServerProfile.xaml
+++ b/FAST2/ServerProfile.xaml
@@ -18,7 +18,7 @@
 
 
              mc:Ignorable="d"
-             d:DesignHeight="570.4"
+             d:DesignHeight="620.4"
              d:DesignWidth="796.8">
 
 
@@ -105,8 +105,17 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <StackPanel Grid.ColumnSpan="2">
-                                <Label Margin="2" Content="Headless Client"/>
-                                <ToggleButton Name="IHeadlessClientEnabled" Style="{StaticResource MaterialDesignSwitchToggleButton}" IsChecked="False" HorizontalAlignment="Right" Margin="2,-25,5,0" ToolTip="Enable HC"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="120"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Label Margin="1" Content="Headless Client"/><Button Grid.Column="2" Name="ILaunchHeadless" Height="20" Width="20" Margin="5" FontSize="10" ToolTip="Launch a HC" IsEnabled="False">
+                                        <materialDesign:PackIcon Kind="Play" Width="12" Height="12" Margin="-12,0,-15,0"/>
+                                    </Button>
+                                    <ToggleButton Grid.Column="2" Name="IHeadlessClientEnabled" Style="{StaticResource MaterialDesignSwitchToggleButton}" IsChecked="False" HorizontalAlignment="Right" Margin="0,0,5,0" ToolTip="Enable HC"/>
+                                </Grid>
                                 <Separator Style="{StaticResource MaterialDesignSeparator}" Margin="-8"/>
                             </StackPanel>
 
@@ -135,9 +144,8 @@
                                 <Label Margin="2" Content="Network"/>
                                 <Separator Style="{StaticResource MaterialDesignSeparator}" Margin="-8"/>
                             </StackPanel>
-
                             <CheckBox Name="ILoopback" Grid.Row="1" Style="{StaticResource MaterialDesignCheckBox}" Content="Loopback" Foreground="{DynamicResource MaterialDesignBody}" Margin="5"/>
-                            <CheckBox Name="IUpnp" Grid.Row="2" Style="{StaticResource MaterialDesignCheckBox}" Content="UPNP" Foreground="{DynamicResource MaterialDesignBody}" Margin="5"/>
+                            <CheckBox Name="IUPNP" Grid.Row="2" Style="{StaticResource MaterialDesignCheckBox}" Content="UPNP" Foreground="{DynamicResource MaterialDesignBody}" Margin="5"/>
                             <CheckBox Name="INetlog" Grid.Row="3" Style="{StaticResource MaterialDesignCheckBox}" Content="Netlog" Foreground="{DynamicResource MaterialDesignBody}" Margin="5"/>
                         </Grid>
                     </materialDesign:Card>

--- a/FAST2/ServerProfile.xaml.vb
+++ b/FAST2/ServerProfile.xaml.vb
@@ -280,10 +280,12 @@ Class ServerProfile
                     IHcIpGroup.IsEnabled = True
                     IHcSliderGroup.IsEnabled = True
                     IHeadlessClientEnabled.ToolTip = "Disable HC"
+                    ILaunchHeadless.IsEnabled = True
                 Else
                     IHcIpGroup.IsEnabled = False
                     IHcSliderGroup.IsEnabled = False
                     IHeadlessClientEnabled.ToolTip = "Enable HC"
+                    ILaunchHeadless.IsEnabled = False
                 End If
             Case "IVonEnabled"
                 If IVonEnabled.IsChecked Then
@@ -398,7 +400,7 @@ Class ServerProfile
     End Sub
 
     Private Sub ModsPaste_Click(sender As Controls.Button, e As RoutedEventArgs) Handles IClientModsPaste.Click, IServerModsPaste.Click, IHeadlessModsPaste.Click
-        If ModsToCopy IsNot String.Empty
+        If ModsToCopy IsNot String.Empty Then
             Select Case sender.Name
                 Case "IServerModsPaste"
                     IServerModsList.SelectedValue = ModsToCopy

--- a/FAST2/ServerProfile.xaml.vb
+++ b/FAST2/ServerProfile.xaml.vb
@@ -605,26 +605,30 @@ Class ServerProfile
             sProcess.Start()
 
             If IHeadlessClientEnabled.IsChecked Then
-                For hc = 1 To INoOfHeadlessClients.Value
-                    Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profilePath & " -nosound -port=" & IPort.Text
-                    Dim hcMods As String = Nothing
-
-                    For Each addon In IHeadlessModsList.SelectedItems
-                        hcMods = hcMods & addon & ";"
-                    Next
-
-                    hcCommandLine = hcCommandLine & " ""-mod=" & hcMods & """"
-
-                    Clipboard.SetText(hcCommandLine)
-
-                    Dim hcStartInfo As New ProcessStartInfo(IExecutable.Text, hcCommandLine)
-                    Dim hcProcess As New Process With {
-                            .StartInfo = hcStartInfo
-                        }
-                    hcProcess.Start()
-                Next
+                LaunchHeadlessClient(profilePath)
             End If
         End If
+    End Sub
+
+    Private Sub LaunchHeadlessClient(profile_path As String)
+        For hc = 1 To INoOfHeadlessClients.Value
+            Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profile_path & " -nosound -port=" & IPort.Text
+            Dim hcMods As String = Nothing
+
+            For Each addon In IHeadlessModsList.SelectedItems
+                hcMods = hcMods & addon & ";"
+            Next
+
+            hcCommandLine = hcCommandLine & " ""-mod=" & hcMods & """"
+
+            Clipboard.SetText(hcCommandLine)
+
+            Dim hcStartInfo As New ProcessStartInfo(IExecutable.Text, hcCommandLine)
+            Dim hcProcess As New Process With {
+                    .StartInfo = hcStartInfo
+                }
+            hcProcess.Start()
+        Next
     End Sub
 
     Private Sub WriteConfigFiles(profile As String)

--- a/FAST2/ServerProfile.xaml.vb
+++ b/FAST2/ServerProfile.xaml.vb
@@ -605,30 +605,30 @@ Class ServerProfile
             sProcess.Start()
 
             If IHeadlessClientEnabled.IsChecked Then
-                LaunchHeadlessClient(profilePath)
+                For hc = 1 To INoOfHeadlessClients.Value
+                    LaunchHeadlessClient(profilePath)
+                Next
             End If
         End If
     End Sub
 
     Private Sub LaunchHeadlessClient(profile_path As String)
-        For hc = 1 To INoOfHeadlessClients.Value
-            Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profile_path & " -nosound -port=" & IPort.Text
-            Dim hcMods As String = Nothing
+        Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profile_path & " -nosound -port=" & IPort.Text
+        Dim hcMods As String = Nothing
 
-            For Each addon In IHeadlessModsList.SelectedItems
-                hcMods = hcMods & addon & ";"
-            Next
-
-            hcCommandLine = hcCommandLine & " ""-mod=" & hcMods & """"
-
-            Clipboard.SetText(hcCommandLine)
-
-            Dim hcStartInfo As New ProcessStartInfo(IExecutable.Text, hcCommandLine)
-            Dim hcProcess As New Process With {
-                    .StartInfo = hcStartInfo
-                }
-            hcProcess.Start()
+        For Each addon In IHeadlessModsList.SelectedItems
+            hcMods = hcMods & addon & ";"
         Next
+
+        hcCommandLine = hcCommandLine & " ""-mod=" & hcMods & """"
+
+        Clipboard.SetText(hcCommandLine)
+
+        Dim hcStartInfo As New ProcessStartInfo(IExecutable.Text, hcCommandLine)
+        Dim hcProcess As New Process With {
+                .StartInfo = hcStartInfo
+            }
+        hcProcess.Start()
     End Sub
 
     Private Sub WriteConfigFiles(profile As String)

--- a/FAST2/ServerProfile.xaml.vb
+++ b/FAST2/ServerProfile.xaml.vb
@@ -614,8 +614,14 @@ Class ServerProfile
         End If
     End Sub
 
-    Private Sub LaunchHeadlessClient(profile_path As String)
-        Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profile_path & " -nosound -port=" & IPort.Text
+    Private Sub ILaunchHeadless_Click(sender As Object, e As RoutedEventArgs) Handles ILaunchHeadless.Click
+        Dim profileName As String = Functions.SafeName(IDisplayName.Content)
+        Dim profilePath As String = _profilesPath & profileName & "\"
+        LaunchHeadlessClient(profilePath)
+    End Sub
+
+    Private Sub LaunchHeadlessClient(profilePath As String)
+        Dim hcCommandLine As String = "-client -connect=127.0.0.1 -password=" & IPassword.Text & " -profiles=" & profilePath & $" -nosound -port=" & IPort.Text
         Dim hcMods As String = Nothing
 
         For Each addon In IHeadlessModsList.SelectedItems


### PR DESCRIPTION
Allows Headless Clients to be launched independently of the server at any time. Fixes #63 