### PR TITLE
Fix Integer overflow issue with mod IDs

### DIFF
--- a/FAST2/Models/SteamMod.vb
+++ b/FAST2/Models/SteamMod.vb
@@ -7,7 +7,7 @@ Namespace Models
         Private Sub New()
         End Sub
 
-        Private Sub New(workshopId As Int32, name As String, author As String, steamLastUpdated As Int32, Optional privateMod As Boolean = False)
+        Private Sub New(workshopId As Long, name As String, author As String, steamLastUpdated As Int32, Optional privateMod As Boolean = False)
             Me.WorkshopId = workshopId
             Me.Name = name
             Me.Author = author
@@ -15,7 +15,7 @@ Namespace Models
             Me.PrivateMod = privateMod
         End Sub
 
-        Public Property WorkshopId As Integer = Nothing
+        Public Property WorkshopId As Long = Nothing
         Public Property Name As String = String.Empty
         Public Property Author As String = String.Empty
         Public Property SteamLastUpdated As Integer = Nothing
@@ -23,7 +23,7 @@ Namespace Models
         Private Property PrivateMod As Boolean = False
         Public Property Status As String = "Not Installed"
 
-        Public Shared Sub DeleteSteamMod(workshopId As Int32)
+        Public Shared Sub DeleteSteamMod(workshopId As Long)
             Dim currentMods = GetSteamMods()
 
             currentMods.RemoveAll(Function(x) x.WorkshopId = workshopId)

--- a/FAST2/Models/SteamWebApi.vb
+++ b/FAST2/Models/SteamWebApi.vb
@@ -24,8 +24,8 @@ Namespace Models
         End Function
 
         'Get mod info for single mod
-        Public Shared Function GetSingleFileDetails(modId As Integer) As JObject
-            Dim response = ApiCall("https://api.steampowered.com/IPublishedFileService/GetDetails/v1?key=" & My.Settings.SteamApiKey & V3 & modId)
+        Public Shared Function GetSingleFileDetails(modId As Long) As JObject
+            Dim response = ApiCall("https://api.steampowered.com/IPublishedFileService/GetDetails/v1?key=" & My.Settings.steamApiKey & V3 & modId)
 
             Return response.SelectToken("response.publishedfiledetails[0]")
         End Function

--- a/FAST2/Models/SteamWebApi.vb
+++ b/FAST2/Models/SteamWebApi.vb
@@ -25,7 +25,7 @@ Namespace Models
 
         'Get mod info for single mod
         Public Shared Function GetSingleFileDetails(modId As Long) As JObject
-            Dim response = ApiCall("https://api.steampowered.com/IPublishedFileService/GetDetails/v1?key=" & My.Settings.steamApiKey & V3 & modId)
+            Dim response = ApiCall("https://api.steampowered.com/IPublishedFileService/GetDetails/v1?key=" & My.Settings.SteamApiKey & V3 & modId)
 
             Return response.SelectToken("response.publishedfiledetails[0]")
         End Function

--- a/FAST2/SteamMods.xaml.vb
+++ b/FAST2/SteamMods.xaml.vb
@@ -157,7 +157,7 @@ Public Class SteamMods
         End If
     End Sub
 
-    Private Shared Sub UpdateMod(modId As Int32, modName As String, Optional singleMod As Boolean = True)
+    Private Shared Sub UpdateMod(modId As Long, modName As String, Optional singleMod As Boolean = True)
         If MainWindow.Instance.ReadyToUpdate Then
             Dim modPath As String = My.Settings.steamCMDPath & "\steamapps\workshop\content\107410\" & modId
 


### PR DESCRIPTION
So feel free to tell me i'm completely wrong here, as I'm really not a VB developer at all; but I was running into issues with the app tonight adding my own mod and decided to look into it myself. I noticed a few Overflow issues and it turns out it was based around the Mod IDs.

I created a workshop mod today and was given the ID 2222310639. Which is greater than the 32bit Integer max of 2147483647. Thus the app fails silently while trying to add it.

This PR converts each of those Integers to Longs which should future proof longer than I think Steam will be still using these IDs.