### PR TITLE
Fix incorrect Substring logic causing launcher file imports to fail

### DIFF
--- a/FAST2/SteamMods.xaml.vb
+++ b/FAST2/SteamMods.xaml.vb
@@ -115,9 +115,7 @@ Public Class SteamMods
                 If modLine.Contains("data-type=""Link"">") Then
                     Dim link As String
                     link = modLine.Substring(modLine.IndexOf("http://steam", StringComparison.Ordinal))
-                    link = StrReverse(link)
-                    link = link.Substring(link.IndexOf("epyt-atad", StringComparison.Ordinal) + 11)
-                    link = StrReverse(link)
+                    link = link.Substring(0, Len(link) - 4)
                     SteamMod.AddSteamMod(link, True)
                 End If
             Loop


### PR DESCRIPTION
As per my other PR, feel free to tell me if I've steered wrong here; but testing locally this Substring fix seems to strip the final `</a>` from the import link before it's passed on to `SteamMod.AddSteamMod()` which allows the file import to continue. Maybe the SteamAPI was changed at some point which broke the previous implementation, as it was stripping a majority of the IDs from the URLs.

I've tested this with my local exported HTML modset from the A3 client and all mods are pulled into the FAST2 Application just fine, though I'm aware there may be some edge cases I'm not thinking of.